### PR TITLE
Migrate from ReactUWP to Microsoft::ReactNative

### DIFF
--- a/ReactRootView2.cpp.patch
+++ b/ReactRootView2.cpp.patch
@@ -1,0 +1,24 @@
+22,26c22,26
+<   if (Dispatcher().HasThreadAccess()) {
+<     SystemNavigationManager::GetForCurrentView().BackRequested(
+<         [host = std::move(host)](IInspectable sender, BackRequestedEventArgs e) {
+<           ReactRootView::OnBackRequested(host, sender, e);
+<         });
+---
+>   //if (Dispatcher().HasThreadAccess()) {
+>   //  SystemNavigationManager::GetForCurrentView().BackRequested(
+>   //      [host = std::move(host)](IInspectable sender, BackRequestedEventArgs e) {
+>   //        ReactRootView::OnBackRequested(host, sender, e);
+>   //      });
+28,32c28,32
+<     Window::Current().CoreWindow().Dispatcher().AcceleratorKeyActivated(
+<         [host = std::move(host)](CoreDispatcher sender, AcceleratorKeyEventArgs e) {
+<           ReactRootView::OnAcceleratorKeyActivated(host, sender, e);
+<         });
+<   }
+---
+>   //  Window::Current().CoreWindow().Dispatcher().AcceleratorKeyActivated(
+>   //      [host = std::move(host)](CoreDispatcher sender, AcceleratorKeyEventArgs e) {
+>   //        ReactRootView::OnAcceleratorKeyActivated(host, sender, e);
+>   //      });
+>   //}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "\"C:\\Program Files\\Git\\usr\\bin\\patch.exe\" -i ReactRootView2.cpp.patch node_modules\\react-native-windows\\Microsoft.ReactNative\\ReactRootView2.cpp",
     "start": "react-native start"
   },
   "dependencies": {

--- a/windows/UWPApp/ReactNativeWinRT.h
+++ b/windows/UWPApp/ReactNativeWinRT.h
@@ -10,7 +10,7 @@ namespace winrt::UWPApp::implementation
 		ReactNativeWinRT();
 		Windows::UI::Xaml::Controls::Grid ReactRootView();
 	private:
-		react::uwp::ReactControl reactRootView_;
+		Microsoft::ReactNative::ReactNativeHost reactNativeHost_;
 	};
 }
 

--- a/windows/UWPApp/ReactNativeWinRT.idl
+++ b/windows/UWPApp/ReactNativeWinRT.idl
@@ -1,9 +1,9 @@
 namespace UWPApp
 {
-	[default_interface]
-	runtimeclass ReactNativeWinRT
-	{
-	  ReactNativeWinRT();
-	  Windows.UI.Xaml.Controls.Grid ReactRootView{ get; };
-	}
+  [default_interface]
+  runtimeclass ReactNativeWinRT
+  {
+    ReactNativeWinRT();
+    Windows.UI.Xaml.Controls.Grid ReactRootView{ get; };
+  }
 }

--- a/windows/UWPApp/UWPApp.vcxproj
+++ b/windows/UWPApp/UWPApp.vcxproj
@@ -162,9 +162,6 @@
     <ProjectReference Include="..\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\node_modules\react-native-windows\ReactUWP\ReactUWP.vcxproj">
-      <Project>{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}</Project>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/windows/UWPApp/pch.h
+++ b/windows/UWPApp/pch.h
@@ -9,4 +9,4 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.h>
 
-#include <winrt/react.uwp.h>
+#include <winrt/Microsoft.ReactNative.h>

--- a/windows/rnw.sln
+++ b/windows/rnw.sln
@@ -35,8 +35,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "win32", "win32\win32.vcxpro
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UWPApp", "UWPApp\UWPApp.vcxproj", "{EFBE8C95-879C-43D0-BE55-E7373D5DBF68}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactUWP", "..\node_modules\react-native-windows\ReactUWP\ReactUWP.vcxproj", "{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "JavaScript", "JavaScript", "{7837A845-915B-462D-8572-B4C83D98DE1D}"
 	ProjectSection(SolutionItems) = preProject
 		..\App.js = ..\App.js
@@ -49,8 +47,6 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
@@ -98,10 +94,6 @@ Global
 		{EFBE8C95-879C-43D0-BE55-E7373D5DBF68}.Release|x64.ActiveCfg = Release|x64
 		{EFBE8C95-879C-43D0-BE55-E7373D5DBF68}.Release|x64.Build.0 = Release|x64
 		{EFBE8C95-879C-43D0-BE55-E7373D5DBF68}.Release|x64.Deploy.0 = Release|x64
-		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x64.ActiveCfg = Debug|x64
-		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x64.Build.0 = Debug|x64
-		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x64.ActiveCfg = Release|x64
-		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -117,7 +109,6 @@ Global
 		{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
-		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}

--- a/windows/win32/main.cpp
+++ b/windows/win32/main.cpp
@@ -107,6 +107,8 @@ int CALLBACK WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 		DispatchMessage(&msg);
 	}
 
+	// This works around a cpp/winrt bug with composable/aggregable types tracked by Microsoft via 22116519
+	reactRootView.as<::IUnknown>()->Release();
 	return 0;
 }
 

--- a/windows/win32/win32.vcxproj
+++ b/windows/win32/win32.vcxproj
@@ -54,7 +54,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">


### PR DESCRIPTION
It crashes right now.
You need to disable those lines > https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/ReactRootView2.cpp#L22-L32
Added a patch